### PR TITLE
⭐ feat: enable on-disk compilation cache by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,8 @@ type Config struct {
 	// be created and returned.
 	ModuleConfigFactory *WazeroModuleConfigFactory
 
+	RuntimeConfigFactory *WazeroRuntimeConfigFactory
+
 	OverrideLogger *log.Logger // essentially a *slog.Logger, currently using an alias to flatten the version discrepancy
 }
 


### PR DESCRIPTION
To improve the bootstrapping speed, which has become a major overhead, we will cache the compiled WebAssembly module. Given that it is usually the case that every program importing WATER will be only using one or few WebAssembly modules, an in-memory cache plus an on-disk cache should suffice. 

This also prevents a possible bug where if the runtime is reused to compile the same WebAssembly module for multiple times and the first one is closed after the latter ones are built but before (functions from) them are getting called, an error will be caused due to the cache is missing (deleted when the first instance is closed). 

Close #34. 