### PR TITLE
✅ ci: switch to GitHub Actions official M1 runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ env:
   CGO_ENABLED: 0
 
 jobs:
-  test_amd64:
+  test_amd64_not-mac:
     name: go${{ matrix.go }} (${{ matrix.os }}/amd64)
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
         go build -v ./...
         go test -v ./...
 
-  test_linux-arm64-and-riscv64:
+  test_not-amd64_linux:
     name: go${{ matrix.go }} (linux/${{ matrix.arch }})
     strategy:
       matrix:
@@ -47,13 +47,30 @@ jobs:
       run:  |
         GOARCH=${{ matrix.arch }} go build -v ./...
         GOARCH=${{ matrix.arch }} go test -v ./...
-
-  test_macos-arm64:
+        
+  test_amd64_mac:
     name: go${{ matrix.go }} (macos/arm64)
     strategy:
       matrix:
         go: [ "1.20", "1.21" ] # we support the latest 2 stable versions of Go
-    runs-on: flyci-macos-large-latest-m1 # generously provided by www.flyci.net
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go }}.x # use latest patch version under the minor version
+    - run: go version
+    - name: Build and Test
+      run:  |
+        go build -v ./...
+        go test -v ./...
+
+  test_arm64_mac:
+    name: go${{ matrix.go }} (macos/arm64)
+    strategy:
+      matrix:
+        go: [ "1.20", "1.21" ] # we support the latest 2 stable versions of Go
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: go${{ matrix.go }} (${{ matrix.os }}/amd64)
     strategy:
       matrix:
-        os: [ "ubuntu", "windows", "macos" ] 
+        os: [ "ubuntu", "windows" ] 
         go: [ "1.20", "1.21" ] # we support the latest 2 stable versions of Go
     runs-on: ${{ matrix.os }}-latest # use latest OS image
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
         GOARCH=${{ matrix.arch }} go test -v ./...
         
   test_amd64_mac:
-    name: go${{ matrix.go }} (macos/arm64)
+    name: go${{ matrix.go }} (macos/amd64)
     strategy:
       matrix:
         go: [ "1.20", "1.21" ] # we support the latest 2 stable versions of Go

--- a/README.md
+++ b/README.md
@@ -177,25 +177,24 @@ Currently, it supports the following platforms:
 |       Target       | Compiles? | Tests Pass? |
 | ------------------ | --------- | ----------- | 
 | linux/amd64        | ✅        | ✅         |
-| linux/aarch64      | ✅        | ✅         |
+| linux/arm64        | ✅        | ✅         |
 | linux/riscv64      | ✅        | ✅         |
 | macos/amd64        | ✅        | ✅         |
-| macos/aarch64      | ✅        | ✅         |
+| macos/arm64        | ✅        | ✅         |
 | windows/amd64      | ✅        | ✅         |
-| windows/aarch64    | ✅        | ❓         |
+| windows/arm64      | ✅        | ❓         |
 | others             | ❓        | ❓         |
 
 ## Acknowledgments
 
 * We thank [GitHub.com](https://github.com) for providing GitHub Actions runners for all targets below:
-	* `linux/amd64`
-	* `linux/aarch64`*
-	* `linux/riscv64`*
-	* `macos/amd64`
-	* `windows/amd64`
+	* `linux/amd64` on Ubuntu Latest
+	* `linux/arm64` via [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)
+	* `linux/riscv64` via [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)
+	* `macos/amd64` on macOS 12
+	* `macos/arm64` on macOS 14
+	* `windows/amd64` on Windows Latest
 
-\* Emulated via [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action).
+* We thank [FlyCI.net](https://www.flyci.net) for providing GitHub Actions runners on `macos/arm64` (Apple M1) _in the past_. (We switched to GitHub's `macos-14` runner as of Jan 31 2024)
 
-* We thank [FlyCI.net](https://www.flyci.net) for providing GitHub Actions runners for `macos/aarch64` (Apple M1)
-
-Looking for help: We are currently actively looking for a CI provider for `windows/aarch64` and more platform. Please reach out and let us know if you would like to help.
+We are currently actively looking for a CI provider for more target platforms. Please reach out and let us know if you would like to help.


### PR DESCRIPTION
This PR replaces the flyci's 3rd party M1 runner with GitHub's official M1 runner (macos-14). 

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/