### PR TITLE
fix: wazero runtime/module config direct access

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,6 +114,14 @@ func (c *Config) ModuleConfig() *WazeroModuleConfigFactory {
 	return c.ModuleConfigFactory
 }
 
+func (c *Config) RuntimeConfig() *WazeroRuntimeConfigFactory {
+	if c.RuntimeConfigFactory == nil {
+		c.RuntimeConfigFactory = NewWazeroRuntimeConfigFactory()
+	}
+
+	return c.RuntimeConfigFactory
+}
+
 // Listen creates a new Listener from the config on the specified network and
 // address.
 //

--- a/core.go
+++ b/core.go
@@ -166,7 +166,7 @@ func NewCoreWithContext(ctx context.Context, config *Config) (Core, error) {
 	}
 
 	c.ctx = ctx
-	c.runtime = wazero.NewRuntimeWithConfig(ctx, config.RuntimeConfigFactory.GetConfig())
+	c.runtime = wazero.NewRuntimeWithConfig(ctx, config.RuntimeConfig().GetConfig())
 
 	if c.module, err = c.runtime.CompileModule(ctx, c.config.WATMBinOrPanic()); err != nil {
 		return nil, fmt.Errorf("water: (*Runtime).CompileModule returned error: %w", err)
@@ -293,7 +293,7 @@ func (c *core) Instantiate() (err error) {
 	if c.instance, err = c.runtime.InstantiateModule(
 		c.ctx,
 		c.module,
-		c.config.ModuleConfigFactory.GetConfig()); err != nil {
+		c.config.ModuleConfig().GetConfig()); err != nil {
 		return fmt.Errorf("water: (*Runtime).InstantiateWithConfig returned error: %w", err)
 	}
 

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -20,7 +20,8 @@ import (
 // path and wasm file path.
 func ExampleDialer() {
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
+		TransportModuleBin:  wasmReverse,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterDialer, err := water.NewDialer(config)

--- a/listener_test.go
+++ b/listener_test.go
@@ -20,7 +20,8 @@ import (
 // path and wasm file path.
 func ExampleListener() {
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
+		TransportModuleBin:  wasmReverse,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterListener, err := config.ListenContext(context.Background(), "tcp", "localhost:0")

--- a/relay_test.go
+++ b/relay_test.go
@@ -28,7 +28,8 @@ func ExampleRelay() {
 	defer tcpListener.Close() // skipcq: GO-S2307
 
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
+		TransportModuleBin:  wasmReverse,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterRelay, err := water.NewRelayWithContext(context.Background(), config)

--- a/transport/v0/dialer_test.go
+++ b/transport/v0/dialer_test.go
@@ -17,7 +17,8 @@ import (
 // ExampleDialer demonstrates how to use v0.Dialer as a water.Dialer.
 func ExampleDialer() {
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
+		TransportModuleBin:  wasmReverse,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterDialer, err := v0.NewDialer(config)

--- a/transport/v0/listener_test.go
+++ b/transport/v0/listener_test.go
@@ -23,8 +23,9 @@ func ExampleListener() {
 
 	// start using W.A.T.E.R. API below this line, have fun!
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
-		NetworkListener:    wrappedTcpListener,
+		TransportModuleBin:  wasmReverse,
+		NetworkListener:     wrappedTcpListener,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterListener, err := v0.NewListenerWithContext(context.Background(), config)

--- a/transport/v0/relay_test.go
+++ b/transport/v0/relay_test.go
@@ -25,7 +25,8 @@ func ExampleRelay() {
 	defer tcpListener.Close() // skipcq: GO-S2307
 
 	config := &water.Config{
-		TransportModuleBin: wasmReverse,
+		TransportModuleBin:  wasmReverse,
+		ModuleConfigFactory: water.NewWazeroModuleConfigFactory(),
 	}
 
 	waterRelay, err := v0.NewRelayWithContext(context.Background(), config)

--- a/wazero_config.go
+++ b/wazero_config.go
@@ -38,7 +38,7 @@ func (wmcf *WazeroModuleConfigFactory) Clone() *WazeroModuleConfigFactory {
 // GetConfig returns the latest wazero.ModuleConfig.
 func (wmcf *WazeroModuleConfigFactory) GetConfig() wazero.ModuleConfig {
 	if wmcf == nil {
-		return wazero.NewModuleConfig().WithSysWalltime().WithSysNanotime().WithSysNanosleep().WithRandSource(rand.Reader)
+		panic("water: GetConfig: wmcf is nil")
 	}
 
 	return wmcf.moduleConfig.WithFSConfig(wmcf.fsconfig)
@@ -142,7 +142,7 @@ func (wrcf *WazeroRuntimeConfigFactory) Clone() *WazeroRuntimeConfigFactory {
 // GetConfig returns the latest wazero.RuntimeConfig.
 func (wrcf *WazeroRuntimeConfigFactory) GetConfig() wazero.RuntimeConfig {
 	if wrcf == nil {
-		wrcf = NewWazeroRuntimeConfigFactory()
+		panic("water: GetConfig: wrcf is nil")
 	}
 
 	if wrcf.compilationCache != nil {
@@ -152,7 +152,18 @@ func (wrcf *WazeroRuntimeConfigFactory) GetConfig() wazero.RuntimeConfig {
 	}
 }
 
+func (wrcf *WazeroRuntimeConfigFactory) Interpreter() {
+	wrcf.runtimeConfig = wazero.NewRuntimeConfigInterpreter()
+}
+
+func (wrcf *WazeroRuntimeConfigFactory) Compiler() {
+	wrcf.runtimeConfig = wazero.NewRuntimeConfigCompiler()
+}
+
 // SetCompilationCache sets the CompilationCache for the WebAssembly module.
+//
+// Calling this function will not update the global CompilationCache and therefore
+// disable the automatic sharing of the cache between multiple WebAssembly modules.
 func (wrcf *WazeroRuntimeConfigFactory) SetCompilationCache(cache wazero.CompilationCache) {
 	wrcf.compilationCache = cache
 }
@@ -170,6 +181,9 @@ func getGlobalCompilationCache() wazero.CompilationCache {
 	return globalCompilationCache
 }
 
+// SetGlobalCompilationCache sets the global CompilationCache for the WebAssembly
+// runtime. This is useful for sharing the cache between multiple WebAssembly
+// modules and should be called before any WebAssembly module is instantiated.
 func SetGlobalCompilationCache(cache wazero.CompilationCache) {
 	globalCompilationCache = cache
 }


### PR DESCRIPTION
These direct access should be replaced with corresponding functions, such that some default behavior added by us will be executed correctly with or without user intervention. 